### PR TITLE
new: usr: All sinks can now filter the input data.

### DIFF
--- a/lib/flowbber/components/__init__.py
+++ b/lib/flowbber/components/__init__.py
@@ -21,5 +21,5 @@ flowbber.components.component module entry point.
 
 from .source import Source  # noqa
 from .aggregator import Aggregator  # noqa
-from .sink import Sink  # noqa
+from .sink import Sink, FilterSink  # noqa
 from .base import TimeExceededError, CrashError  # noqa

--- a/lib/flowbber/plugins/sinks/archive.py
+++ b/lib/flowbber/plugins/sinks/archive.py
@@ -120,15 +120,16 @@ Pretty output.
 
 from pathlib import Path
 
-from flowbber.components import Sink
+from flowbber.components import FilterSink
 from flowbber.logging import get_logger
 
 
 log = get_logger(__name__)
 
 
-class ArchiveSink(Sink):
+class ArchiveSink(FilterSink):
     def declare_config(self, config):
+        super().declare_config(config)
 
         config.add_option(
             'output',
@@ -167,6 +168,10 @@ class ArchiveSink(Sink):
 
     def distribute(self, data):
         from ujson import dumps
+
+        # Allow to filter data
+        super().distribute(data)
+
         outfile = Path(self.config.output.value)
 
         # Re-check no file exists, in case it was created during execution

--- a/lib/flowbber/plugins/sinks/influxdb.py
+++ b/lib/flowbber/plugins/sinks/influxdb.py
@@ -414,8 +414,8 @@ from datetime import datetime
 
 from pprintpp import pformat
 
-from flowbber.components import Sink
 from flowbber.logging import get_logger
+from flowbber.components import FilterSink
 
 
 log = get_logger(__name__)
@@ -515,8 +515,9 @@ def transform_to_points(timestamp, flat):
     return points
 
 
-class InfluxDBSink(Sink):
+class InfluxDBSink(FilterSink):
     def declare_config(self, config):
+        super().declare_config(config)
 
         # Connection options
         config.add_option(
@@ -644,6 +645,9 @@ class InfluxDBSink(Sink):
 
     def distribute(self, data):
         from influxdb import InfluxDBClient
+
+        # Allow to filter data
+        super().distribute(data)
 
         # Get key
         if self.config.key.value is None:

--- a/lib/flowbber/plugins/sinks/mongodb.py
+++ b/lib/flowbber/plugins/sinks/mongodb.py
@@ -403,8 +403,8 @@ beginning of any key in the collected data (see MongoDB data safety above).
 
 """  # noqa
 
-from flowbber.components import Sink
 from flowbber.logging import get_logger
+from flowbber.components import FilterSink
 
 
 log = get_logger(__name__)
@@ -433,8 +433,9 @@ def mongodb_safe(data, dotreplace, dollarreplace):
     return safe_value(data)
 
 
-class MongoDBSink(Sink):
+class MongoDBSink(FilterSink):
     def declare_config(self, config):
+        super().declare_config(config)
 
         # Connection options
         config.add_option(
@@ -562,6 +563,9 @@ class MongoDBSink(Sink):
 
     def distribute(self, data):
         from pymongo import MongoClient
+
+        # Allow to filter data
+        super().distribute(data)
 
         # Get key
         if self.config.key.value is None:

--- a/lib/flowbber/plugins/sinks/print.py
+++ b/lib/flowbber/plugins/sinks/print.py
@@ -49,13 +49,20 @@ large data structures.
 
 """
 
-from flowbber.components import Sink
 from flowbber.logging import print
+from flowbber.components import FilterSink
 
 
-class PrintSink(Sink):
+class PrintSink(FilterSink):
+    def declare_config(self, config):
+        super().declare_config(config)
+
     def distribute(self, data):
         from pprintpp import pformat
+
+        # Allow to filter data
+        super().distribute(data)
+
         print(pformat(data))
 
 

--- a/lib/flowbber/plugins/sinks/template.py
+++ b/lib/flowbber/plugins/sinks/template.py
@@ -258,15 +258,17 @@ And then in your template:
 from pathlib import Path
 from importlib import import_module
 
-from flowbber.components import Sink
 from flowbber.logging import get_logger
+from flowbber.components import FilterSink
 
 
 log = get_logger(__name__)
 
 
-class TemplateSink(Sink):
+class TemplateSink(FilterSink):
     def declare_config(self, config):
+        super().declare_config(config)
+
         config.add_option(
             'template',
             schema={
@@ -316,6 +318,9 @@ class TemplateSink(Sink):
 
     def distribute(self, data):
         from jinja2 import Template
+
+        # Allow to filter data
+        super().distribute(data)
 
         # Determine schema
         template_uri = self.config.template.value


### PR DESCRIPTION
This fixes #3.

In this PR a new ``FilterAggregator`` is added and with it the user is now able to filter the whole data structure using an aggregator in its pipeline.

In addition, a ``FilterSink`` is also added, and all bundled Sinks were changed to inherit from it. With this change the user is able to filter the data for each specific sink.

In both cases, instead of a ``filter`` configuration option, two options ``include`` and ``exclude`` were added. Both are lists of fnmatch patterns to allow to specify a large set of options for filtering.