### PR TITLE
fix: dev: Fix pytest source to show error and failure

### DIFF
--- a/lib/flowbber/plugins/sources/pytest.py
+++ b/lib/flowbber/plugins/sources/pytest.py
@@ -203,25 +203,30 @@ class PytestSource(Source):
         # Add test cases
         for child in root:
             assert child.tag == 'testcase', 'Malformed XML child element'
-            testcase = {
-                key: cast(child.attrib[key])
-                for key, cast in [
-                    ('file', str),
-                    ('line', int),
-                    ('classname', str),
-                    ('name', str),
-                    ('time', float),
-                ]
-            }
 
-            properties = []
-            testcase['properties'] = properties
-
+            # Form an unique name base on classname and testcase name
             tckey = '{}.{}'.format(
                 child.attrib['classname'],
                 child.attrib['name']
             )
-            testcases[tckey] = testcase
+            # Pytest creates duplicates of a test case if there is an error and
+            # a failure. It does so in order to be compliant with JUnit schema
+            # See https://github.com/pytest-dev/pytest/issues/2228
+            testcase = testcases.get(tckey)
+            if testcase is None:
+                testcase = {
+                    key: cast(child.attrib[key])
+                    for key, cast in [
+                        ('file', str),
+                        ('line', int),
+                        ('classname', str),
+                        ('name', str),
+                        ('time', float),
+                    ]
+                }
+                properties = []
+                testcase['properties'] = properties
+                testcases[tckey] = testcase
 
             # Add properties
             subchild = child.find('properties')


### PR DESCRIPTION
Pytest has decided to follow the [JUnit schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd) for the xml plugin. This forbids `testcases` to have a `failure` and an `error` at the same time. When this scenario is hit, pytest decided to duplicate the `testcase` element and report them separately.

More info in this issue: pytest-dev/pytest#2228