### PR TITLE
fix: usr: Memcheck stack might be a list

### DIFF
--- a/lib/flowbber/plugins/sources/valgrind/memcheck.py
+++ b/lib/flowbber/plugins/sources/valgrind/memcheck.py
@@ -201,7 +201,7 @@ class ValgrindMemcheckSource(Source):
                 'No such file {}'.format(infile)
             )
 
-        doc = parse(infile.read_text(), force_list=('error',))
+        doc = parse(infile.read_text(), force_list=('error', 'stack',))
         return doc['valgrindoutput']
 
 


### PR DESCRIPTION
According to the [xml schema](https://github.com/tbert/vigilante/blob/master/data/xmlschemas/valgrind-memcheck-xml-output.xsd#L122), stack has an unbounded max attributes. To have one single data type, force it to always be parsed as a list.