### PR TITLE
Add support for new gtest's xml output format

### DIFF
--- a/examples/test/new_gtest.xml
+++ b/examples/test/new_gtest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="5" failures="2" disabled="1" errors="0" timestamp="2017-09-20T02:03:43" time="0.001" name="AllTests">
+  <testsuite name="test1" tests="2" failures="1" disabled="0" errors="0" time="0">
+    <testcase name="test_a" status="run" time="0" classname="test1">
+      <properties>
+        <property name="test_id" value="1:test_a" />
+        <property name="seed" value="123456" />
+      </properties>
+    </testcase>
+    <testcase name="test_b" status="run" time="0" classname="test1">
+      <failure message="/home/kuralabs/googletest-example/tests/test1.cpp:12&#x0A;      Expected: 0&#x0A;To be equal to: 1" type=""><![CDATA[/home/kuralabs/googletest-example/tests/test1.cpp:12
+      Expected: 0
+To be equal to: 1]]></failure>
+      <properties>
+        <property name="test_id" value="1:test_b" />
+        <property name="seed" value="123456" />
+      </properties>
+    </testcase>
+  </testsuite>
+  <testsuite name="test2" tests="3" failures="1" disabled="1" errors="0" time="0">
+    <testcase name="test_a" status="run" time="0" classname="test2">
+      <properties>
+        <property name="test_id" value="2:test_a" />
+        <property name="seed" value="123456" />
+      </properties>
+    </testcase>
+    <testcase name="test_b" status="run" time="0" classname="test2">
+      <failure message="/home/kuralabs/googletest-example/tests/test2.cpp:12&#x0A;      Expected: 0&#x0A;To be equal to: 1" type=""><![CDATA[/home/kuralabs/googletest-example/tests/test2.cpp:12
+      Expected: 0
+To be equal to: 1]]></failure>
+      <properties>
+        <property name="test_id" value="2:test_b" />
+        <property name="seed" value="123456" />
+      </properties>
+    </testcase>
+    <testcase name="DISABLED_test_c" status="notrun" time="0" classname="test2" />
+  </testsuite>
+</testsuites>

--- a/examples/test/pipeline.toml
+++ b/examples/test/pipeline.toml
@@ -12,6 +12,13 @@ id = "gtest"
     [sources.config]
     xmlpath = "{pipeline.dir}/gtest.xml"
 
+[[sources]]
+type = "gtest"
+id = "new_gtest"
+
+    [sources.config]
+    xmlpath = "{pipeline.dir}/new_gtest.xml"
+
 [[sinks]]
 type = "print"
 id = "print"

--- a/lib/flowbber/plugins/sources/gtest.py
+++ b/lib/flowbber/plugins/sources/gtest.py
@@ -251,6 +251,19 @@ class GTestSource(Source):
                     ('time', float),
                 ])
 
+                # Fetch properties: the properties are no longer attributes
+                # in the testcase. After the release of gtest v1.8.1 they
+                # are saved in the format <property name='' value''> inside
+                # 'properties' under each testcase.
+                testcase.setdefault(
+                    'properties', {
+                        prop.get('name'): prop.get('value')
+                        for caseroot in subchild
+                        if 'properties' == caseroot.tag
+                        for prop in caseroot.findall('property')
+                    }
+                )
+
                 # Fetch failures
                 failures = [
                     failure.text for failure in subchild


### PR DESCRIPTION
The properties are no longer attributes in the testcase tag.

This commit https://github.com/google/googletest/commit/e89190066608137b35dca32e28428126c04366dc which became part of the googletest 1.8.1 release changed this.

Now, a test case has a new tag called `<properties>`, with tags inside with the form `<property name='' value''>`:

This PR changes the gtest source to account for this change.