### PR TITLE
Exclude files

### DIFF
--- a/examples/filter/.gitignore
+++ b/examples/filter/.gitignore
@@ -1,0 +1,1 @@
+data.json

--- a/examples/filter/exclude1
+++ b/examples/filter/exclude1
@@ -1,0 +1,6 @@
+# We repeat this value from the pipeline
+input.exclude0
+
+# New values
+input.exclude1.excludethis
+input.exclude1.andthese*

--- a/examples/filter/exclude2
+++ b/examples/filter/exclude2
@@ -1,0 +1,7 @@
+input.exclude2.*excludethese*
+
+# Repeated
+input.exclude2.*excludethese*
+
+# Doesn't exists
+input.exclude2.inexistent*

--- a/examples/filter/input.json
+++ b/examples/filter/input.json
@@ -1,0 +1,19 @@
+{
+    "exclude0": true,
+    "exclude1": {
+        "excludethis": false,
+        "andthese1": 1,
+        "andthese2": 2,
+        "andthese3": 3,
+        "butnotthis": {
+            "some": "data",
+            "andsome": "more"
+        }
+    },
+    "exclude2": {
+        "mayexcludethese": true,
+        "alsoexcludethese": true,
+        "excludethese1": true,
+        "neverthese": false
+    }
+}

--- a/examples/filter/pipeline.toml
+++ b/examples/filter/pipeline.toml
@@ -1,0 +1,23 @@
+[[sources]]
+type = "json"
+id = "input"
+
+    [sources.config]
+    file_uri = "file://{pipeline.dir}/input.json"
+
+
+[[sinks]]
+type = "archive"
+id = "exclude"
+
+    [sinks.config]
+    output = "{pipeline.dir}/data.json"
+    override = true
+    create_parents = true
+    pretty = true
+
+    exclude = ["input.exclude0"]
+    exclude_files = [
+        "{pipeline.dir}/exclude1",
+        "{pipeline.dir}/exclude2",
+    ]

--- a/lib/flowbber/config.py
+++ b/lib/flowbber/config.py
@@ -65,9 +65,10 @@ class Configurator:
         self._configtype = None
 
     def add_option(
-            self, key,
-            default=None, optional=False,
-            schema=None, secret=False):
+        self, key,
+        default=None, optional=False,
+        schema=None, secret=False,
+    ):
         """
         Declare an option.
 

--- a/lib/flowbber/plugins/sinks/archive.py
+++ b/lib/flowbber/plugins/sinks/archive.py
@@ -22,6 +22,12 @@ Archive
 
 This sink writes all collected data to a JSON file.
 
+.. important::
+
+   This class inherits several inclusion and exclusion configuration options
+   for filtering data before using it. See :ref:`filter-sink-options` for more
+   information.
+
 **Dependencies:**
 
 .. code-block:: sh

--- a/lib/flowbber/plugins/sinks/influxdb.py
+++ b/lib/flowbber/plugins/sinks/influxdb.py
@@ -24,6 +24,12 @@ This sink writes all collected data to a InfluxDB_ time series database.
 
 .. _InfluxDB: https://www.influxdata.com/time-series-platform/influxdb/
 
+.. important::
+
+   This class inherits several inclusion and exclusion configuration options
+   for filtering data before using it. See :ref:`filter-sink-options` for more
+   information.
+
 In order to be able to track in time the complex data collected by the sources
 this sink requires to "flatten" the data first. The process will transform an
 arbitrarily deep dictionary tree into a fixed depth dictionary that maps the

--- a/lib/flowbber/plugins/sinks/mongodb.py
+++ b/lib/flowbber/plugins/sinks/mongodb.py
@@ -24,6 +24,12 @@ This sink writes all collected data to a MongoDB_ NoSQL database.
 
 .. _MongoDB: https://www.mongodb.com/
 
+.. important::
+
+   This class inherits several inclusion and exclusion configuration options
+   for filtering data before using it. See :ref:`filter-sink-options` for more
+   information.
+
 The collected data is mostly unaltered from its original form, except that
 MongoDB document keys cannot contain ``.`` (dot) characters and cannot start
 with a ``$`` (dollar) sign.

--- a/lib/flowbber/plugins/sinks/print.py
+++ b/lib/flowbber/plugins/sinks/print.py
@@ -27,6 +27,12 @@ large data structures.
 
 .. _pprintpp: https://github.com/wolever/pprintpp
 
+.. important::
+
+   This class inherits several inclusion and exclusion configuration options
+   for filtering data before using it. See :ref:`filter-sink-options` for more
+   information.
+
 **Dependencies:**
 
 .. code-block:: sh

--- a/lib/flowbber/plugins/sinks/template.py
+++ b/lib/flowbber/plugins/sinks/template.py
@@ -23,6 +23,12 @@ Template
 This sink will render specified Jinja2_ template using the collected data as
 payload.
 
+.. important::
+
+   This class inherits several inclusion and exclusion configuration options
+   for filtering data before using it. See :ref:`filter-sink-options` for more
+   information.
+
 For the following collected data:
 
 .. code-block:: python3

--- a/lib/flowbber/plugins/sinks/template.py
+++ b/lib/flowbber/plugins/sinks/template.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017-2018 KuraLabs S.R.L
+# Copyright (C) 2017-2019 KuraLabs S.R.L
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -374,11 +374,11 @@ The above filter can then be used as:
 
      {
          'type': 'dict',
-         'keyschema': {
+         'keysrules': {
              'type': 'string',
              'empty': False,
          },
-         'valueschema': {
+         'valuesrules': {
              'type': 'string',
              'empty': False,
          },
@@ -477,11 +477,11 @@ class TemplateSink(FilterSink):
             optional=True,
             schema={
                 'type': 'dict',
-                'keyschema': {
+                'keysrules': {
                     'type': 'string',
                     'empty': False,
                 },
-                'valueschema': {
+                'valuesrules': {
                     'type': 'string',
                     'empty': False,
                 },

--- a/lib/flowbber/schema.py
+++ b/lib/flowbber/schema.py
@@ -57,7 +57,7 @@ COMPONENT_SCHEMA = {
         'type': 'dict',
         'default': None,
         'nullable': True,
-        'keyschema': {
+        'keysrules': {
             'type': 'string',
             'regex': SLUG_REGEX,
         },

--- a/lib/flowbber/utils/filter.py
+++ b/lib/flowbber/utils/filter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 KuraLabs S.R.L
+# Copyright (C) 2017-2019 KuraLabs S.R.L
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 Utilities for filtering data.
 """
 
+from pathlib import Path
 from fnmatch import fnmatch
 
 
@@ -78,8 +79,47 @@ def filter_dict(data, include, exclude, joinchar='.'):
     return filter_dict_recursive([], data)
 
 
+def load_filter_file(filepath, encoding='utf-8'):
+    """
+    Load a ".gitignore"-like file describing excluding (or including) fnmatch
+    patterns.
+
+    Empty lines and comments (#) are supported. Patterns returned are unique
+    and in the same order as described in the file.
+
+    :param str filepath: Path to the file. Path objects are also supported
+     (and preferred).
+    :param str encoding: Encoding to use to decode the file.
+
+    :return: List of unique patterns in the file.
+    :rtype: list
+    """
+
+    if not isinstance(filepath, Path):
+        filepath = Path(filepath)
+
+    if not filepath.exists():
+        raise FileNotFoundError(
+            'No such file {}'.format(filepath)
+        )
+
+    patterns = []
+
+    with filepath.open(mode='rt', encoding=encoding) as fd:
+        for raw_line in fd:
+            line = raw_line.strip()
+
+            if not line or line.startswith('#') or line in patterns:
+                continue
+
+            patterns.append(line)
+
+    return patterns
+
+
 __all__ = [
     'included_in',
     'is_wanted',
     'filter_dict',
+    'load_filter_file',
 ]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -15,6 +15,7 @@ ipdb
 # Testing             #
 #######################
 
+deepdiff
 pytest==3.2.5
 pytest-cov==2.5.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ toml
 ujson
 colorlog
 pprintpp
-cerberus
+cerberus>=1.3.1
 setuptools
 pytimeparse
 setproctitle

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,9 +1,12 @@
 from os import environ
+from json import loads
+from shutil import which
 from pathlib import Path
 from subprocess import run
 from collections import namedtuple
 
-from pytest import mark, skip
+from pytest import mark
+from deepdiff import DeepDiff
 
 from flowbber.main import main
 from flowbber.logging import get_logger, setup_logging
@@ -20,37 +23,72 @@ def setup_module(module):
     setup_logging(verbosity=2)
 
 
-@mark.parametrize(['name', 'pipelinedef'], [
-    ['github', 'pipeline.toml'],
-    ['sloc', 'pipeline.toml'],
-    ['basic', 'pipeline.toml'],
-    ['local', 'pipeline.toml'],
-    ['advanced', 'pipeline.json'],
-    ['advanced', 'pipeline.toml'],
-    ['test', 'pipeline.toml'],
-    ['lcov', 'pipeline.toml'],
-    ['valgrind', 'pipeline.toml'],
-    ['config', 'pipeline.toml'],
-    ['archive', 'compress.toml'],
-    ['archive', 'extract.toml'],
-])
-def test_pipelines(name, pipelinedef):
-    # Exceptions ...
-    if name == 'github':
-        if 'GITHUB_TOKEN' not in environ:
-            skip('Missing GITHUB_TOKEN environment variable')
-
-    elif name == 'lcov':
-        # Create coverage files
-        run(['make', '-C', str(examples / name)], check=True)
-
-    # Run pipeline
+def run_pipeline(name, pipelinedef):
     args = Arguments(
         pipeline=examples / name / pipelinedef,
         dry_run=False,
     )
     result = main(args)
     assert result == 0
+
+
+@mark.parametrize(['name', 'pipelinedef'], [
+    ['sloc', 'pipeline.toml'],
+    ['basic', 'pipeline.toml'],
+    ['local', 'pipeline.toml'],
+    ['advanced', 'pipeline.json'],
+    ['advanced', 'pipeline.toml'],
+    ['test', 'pipeline.toml'],
+    ['valgrind', 'pipeline.toml'],
+    ['config', 'pipeline.toml'],
+    ['archive', 'compress.toml'],
+    ['archive', 'extract.toml'],
+])
+def test_pipeline(name, pipelinedef):
+    run_pipeline(name, pipelinedef)
+
+
+@mark.skipif(
+    'GITHUB_TOKEN' not in environ,
+    reason='Missing GITHUB_TOKEN environment variable'
+)
+def test_pipeline_github():
+    run_pipeline('github', 'pipeline.toml')
+
+
+@mark.skipif(
+    not which('make'),
+    reason='"make" is unavailable in your environment'
+)
+def test_pipeline_lcov():
+    # Create coverage files
+    run([which('make'), '-C', str(examples / 'lcov')], check=True)
+    run_pipeline('lcov', 'pipeline.toml')
+
+
+def test_pipeline_filter():
+    run_pipeline('filter', 'pipeline.toml')
+
+    actual = loads(
+        Path(examples / 'filter' / 'data.json').read_text(encoding='utf-8')
+    )
+
+    expected = {
+        'input': {
+            'exclude2': {
+                'neverthese': False,
+            },
+            'exclude1': {
+                'butnotthis': {
+                    'andsome': 'more',
+                    'some': 'data',
+                },
+            },
+        },
+    }
+
+    differences = DeepDiff(actual, expected)
+    assert not differences
 
 
 @mark.parametrize(['script'], [


### PR DESCRIPTION
In this PR:

- Updated schemas to use Cerberus >=1.3.1 definition.
- New include_files and exclude_files options in many Sinks and Sources.

  This feature allows to use many ".gitignore"-like files to exclude and include data in sinks that inherit from the FilterSink, and in other sources.