### PR TITLE
new: usr: Added new field total_issues to valgrind source

### DIFF
--- a/lib/flowbber/plugins/sources/valgrind/__init__.py
+++ b/lib/flowbber/plugins/sources/valgrind/__init__.py
@@ -46,6 +46,14 @@ class ValgrindBaseSource(Source):
             )
 
         doc = parse(infile.read_text(), force_list=('error', 'stack',))
+        # Safe check. Check the documention of why this field is injected into
+        # the collected data.
+        if 'error' in doc['valgrindoutput']:
+            doc['valgrindoutput']['total_issues'] = len(
+                doc['valgrindoutput']['error']
+            )
+        else:
+            doc['valgrindoutput']['total_issues'] = 0
         return doc['valgrindoutput']
 
 

--- a/lib/flowbber/plugins/sources/valgrind/drd.py
+++ b/lib/flowbber/plugins/sources/valgrind/drd.py
@@ -40,6 +40,9 @@ Such XML file can be generated with:
 
 **Data collected:**
 
+Sadly, the XML format doesn't include a total number of issues, just an array of issues.
+A "total_issues' field is injected to allow the user to have much more efficient database queries.
+
 .. code-block:: json
 
     {
@@ -83,6 +86,7 @@ Such XML file can be generated with:
                 "time":"00:00:00:48.866"
             }
         ],
+        "total_issues": 1,
         "error":[
             {
                 "unique":"0x968"

--- a/lib/flowbber/plugins/sources/valgrind/helgrind.py
+++ b/lib/flowbber/plugins/sources/valgrind/helgrind.py
@@ -40,6 +40,9 @@ Such XML file can be generated with:
 
 **Data collected:**
 
+Sadly, the XML format doesn't include a total number of issues, just an array of issues.
+A "total_issues' field is injected to allow the user to have much more efficient database queries.
+
 .. code-block:: json
 
     {
@@ -83,6 +86,7 @@ Such XML file can be generated with:
                 "time":"00:00:00:58.060"
             }
         ],
+        "total_issues": 1,
         "error":[
             {
                 "unique":"0x968"

--- a/lib/flowbber/plugins/sources/valgrind/memcheck.py
+++ b/lib/flowbber/plugins/sources/valgrind/memcheck.py
@@ -38,6 +38,9 @@ Such XML file can be generated with:
 
 **Data collected:**
 
+Sadly, the XML format doesn't include a total number of issues, just an array of issues.
+A "total_issues' field is injected to allow the user to have much more efficient database queries.
+
 .. code-block:: json
 
     {
@@ -73,6 +76,7 @@ Such XML file can be generated with:
         "protocoltool":"memcheck",
         "protocolversion":"4",
         "tool":"memcheck",
+        "total_issues": 1,
         "error":[
             {
                 "kind":"Leak_DefinitelyLost",

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,8 @@ setenv =
     TESTENV_BOOL4 = NO
     TESTENV_ISO8601 = 2019-08-05T14:38:13
 commands =
+    # Clean testing cache
+    rm -rf {toxinidir}/test/__pycache__
     {envpython} -c "import flowbber; print(flowbber.__file__)"
     flake8 {toxinidir}
     py.test -s -vv \


### PR DESCRIPTION
Now the valgrind xml sources will have a new field called: "total_issues"
The idea of this field is to have a count of the amount of errors that
ocurred on the report. Users won't need to calculate the length of the
errors list manually.